### PR TITLE
Fixes Ember.required deprecation

### DIFF
--- a/trees/app/components/json-pretty.js
+++ b/trees/app/components/json-pretty.js
@@ -4,7 +4,7 @@ var JsonPrettyComponent = Ember.Component.extend({
     attributeBindings: ['obj', 'shouldHighlight'],
     classNames: ['json-pretty'],
 
-    obj: Ember.required(),
+    obj: null,
     shouldHighlight: true,
 
     preformattedText: function() {


### PR DESCRIPTION
fixes

```
DEPRECATION: Ember.required is deprecated as its behavior is inconsistent and unreliable.
```

used this PR as reference 

https://github.com/emberjs/data/pull/2911