### PR TITLE
Properly resolve path for monorepo support

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function unwatchedTree(dir) {
 }
 
 EmberCliJsonPretty.prototype.treeFor = function treeFor(name) {
-    var treepath = path.normalize('node_modules/ember-cli-json-pretty/trees/'+name);
+    var treepath = path.resolve(require.resolve('ember-cli-json-pretty'), '..', 'trees', name);
     return (fs.existsSync(treepath)) ? unwatchedTree(treepath) : null;
 };
 


### PR DESCRIPTION
Uses `require.resolve` to find the tree path, so it works in monorepos - where the `node_modules` folder might not be at the project root